### PR TITLE
Cache keyfile to speed up get_env.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except:
 
 
 setup(name = "clrenv",
-      version = "0.1.3",
+      version = "0.1.4",
       description = "A tool to give easy access to environment yaml file to python.",
       author = "Color Genomics",
       author_email = "dev@getcolor.com",


### PR DESCRIPTION
With an environment file with lots of keyfile entries, we're
unnecessarily decrypting the same file many times.  In our config, this
change cuts down the time from ~3.9s to ~0.7s.
