### PR TITLE
[python 3.7] switch from yaml.load() to yaml.full_load()

### DIFF
--- a/clrenv/__init__.py
+++ b/clrenv/__init__.py
@@ -6,7 +6,7 @@ from .path import find_environment_path
 
 def mapping():
     with open(find_environment_path()) as f:
-        return yaml.load(f.read())['mapping']
+        return yaml.full_load(f.read())['mapping']
 
 env = LazyEnv()
 get_env = get_env

--- a/clrenv/lazy_env.py
+++ b/clrenv/lazy_env.py
@@ -49,7 +49,7 @@ def get_env(*mode):
     if not mode in _env:
         y = (_load_current_environment(),)
         upaths = find_user_environment_paths()
-        y = tuple(yaml.load(open(p).read()) for p in upaths if os.path.isfile(p)) + y
+        y = tuple(yaml.full_load(open(p).read()) for p in upaths if os.path.isfile(p)) + y
 
         assignments = tuple(m for m in mode if m.find('=') != -1)
         mode = tuple(m for m in mode if m.find('=') == -1)
@@ -68,7 +68,7 @@ def get_env(*mode):
         e = _merged(*dicts)
 
         for k, v in overrides:
-            for pytype in (yaml.load, eval, int, float, str):
+            for pytype in (yaml.full_load, eval, int, float, str):
                 try:
                     pyval = pytype(v)
                     break
@@ -137,7 +137,7 @@ def _setattr_rec(d, k, v):
 
 def _load_current_environment():
     with open(find_environment_path()) as f:
-        environment = yaml.load(f.read())
+        environment = yaml.full_load(f.read())
     return environment
 
 _kf_dict_cache = {}


### PR DESCRIPTION
PyYAML deprecated yaml.load() in 5.1 since it uses a loader that allows arbitrary code execution. full_load() supports the full YAML syntax but won't execute arbitrary code.

background: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
CVE: https://nvd.nist.gov/vuln/detail/CVE-2017-18342

also see color/color#19212