### PR TITLE
Allow clearing of runtime overrides

### DIFF
--- a/clrenv/lazy_env.py
+++ b/clrenv/lazy_env.py
@@ -58,9 +58,12 @@ class LazyEnv(object):
         return self.__getattr__(key)
 
     def __setattr__(self, key, value):
+        # Internal fields are prefixed with a _
         if key.startswith('_'):
             return object.__setattr__(self, key, value)
 
+        # Ideally we wouldn't be overriding global state like this at all, but at least
+        # make it loud.
         print(f'Manually overriding env.{key} to {value}.', file=sys.stderr)
         if DEBUG_MODE:
             # Get stack and remove this frame.

--- a/clrenv/lazy_env.py
+++ b/clrenv/lazy_env.py
@@ -64,11 +64,11 @@ class LazyEnv(object):
 
         # Ideally we wouldn't be overriding global state like this at all, but at least
         # make it loud.
-        print(f'Manually overriding env.{key} to {value}.', file=sys.stderr)
+        logger.warning(f'Manually overriding env.{key} to {value}.')
         if DEBUG_MODE:
             # Get stack and remove this frame.
             tb = traceback.extract_stack()[:-1]
-            print("".join(traceback.format_list(tb)), file=sys.stderr)
+            logger.warning("".join(traceback.format_list(tb)))
 
         self.__runtime_overrides[key] = value
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ except:
 
 
 setup(name = "clrenv",
-      version = "0.1.7",
+      version = "0.1.8",
       description = "A tool to give easy access to environment yaml file to python.",
       author = "Color Genomics",
       author_email = "dev@getcolor.com",


### PR DESCRIPTION
While the pattern of setting env like this at runtime should be discouraged, we should at least be able to manage it.