### PR TITLE
Properly close files, drop future dependency

### DIFF
--- a/clrenv/lazy_env.py
+++ b/clrenv/lazy_env.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from builtins import object
 from glob import glob
 from itertools import chain

--- a/clrenv/lazy_env.py
+++ b/clrenv/lazy_env.py
@@ -76,9 +76,12 @@ def get_env(*mode):
     global _env
 
     if not mode in _env:
-        y = (_load_current_environment(),)
-        upaths = find_user_environment_paths()
-        y = tuple(safe_load(open(p).read()) for p in upaths if os.path.isfile(p)) + y
+        y = []
+        for path in find_user_environment_paths():
+            if os.path.isfile(path):
+                with open(path) as handle:
+                    y.append(safe_load(handle.read()))
+        y.append(_load_current_environment())
 
         assignments = tuple(m for m in mode if m.find('=') != -1)
         mode = tuple(m for m in mode if m.find('=') == -1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 PyYAML==4.2b1
 munch==2.2.0
-future==0.16.0
 boto3==1.5.36
 -e git+https://github.com/ColorGenomics/clrypt.git@v0.1.6#egg=clrypt

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,11 @@
-import os
-
 try:
-  from setuptools import setup
+    from setuptools import setup
 except:
-  from distutils.core import setup
+    from distutils.core import setup
 
 
 setup(name = "clrenv",
-      version = "0.1.8",
+      version = "0.1.9",
       description = "A tool to give easy access to environment yaml file to python.",
       author = "Color Genomics",
       author_email = "dev@getcolor.com",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ setup(name = "clrenv",
       install_requires=[
         'PyYAML>=4.2b1',
         'munch>=2.2.0',
-        'future==0.16.0',
       ],
       license = "MIT",
       )


### PR DESCRIPTION
Using `open()` without explicitly closing the handle is not a best
practice. Use `open()` as a context manager so that handles will be
closed immediately after their contents are read.

This silences a warning that appears when running with
`PYTHONWARNINGS=always` (or `python -Wd ...`)