### PR TITLE
Clean up path handling

### DIFF
--- a/clrenv/__init__.py
+++ b/clrenv/__init__.py
@@ -2,13 +2,20 @@ import yaml
 
 from .lazy_env import get_env, LazyEnv
 from .load import safe_load
-from .path import find_environment_path
+from .path import environment_paths
 
 
 def mapping():
-    with open(find_environment_path()) as f:
+    """Returns the 'mapping' map from the base enviroment file.
+
+    This contains key names which should be turned into true enviroment
+    variables.
+
+    # TODO(michael.cusack): Refactor this so we don't need to read the yaml
+    twice.
+    """
+    with open(environment_paths()[-1]) as f:
         return safe_load(f.read())["mapping"]
 
 
 env = LazyEnv()
-get_env = get_env

--- a/clrenv/path.py
+++ b/clrenv/path.py
@@ -1,32 +1,74 @@
-import os.path
+"""
+Manages environment yaml file paths.
+
+clrenv expects a base environment file (environment.yaml) and zero or more
+overlay files.
+
+Without configuration (via env vars) looks for an environment.yaml in the cwd
+or one of its parents. This can be set explicitly by setting CLRENV_PATH.
+
+Overlay files (values will mask those set in the base file) can be specified
+with the CLRENV_OVERLAY_PATH env var. Multiple overlays can be specified with a
+colon (:) delimiter. Overlay files that do not exist will be ignored.
+"""
+from pathlib import Path
 from os import environ
+import logging
+
+logger = logging.getLogger(__name__)
+
+DEBUG_MODE = environ.get("CLRENV_DEBUG", "").lower() in ("true", "1")
 
 
-CLRENV_PATH = environ.get("CLRENV_PATH")
-CLRENV_OVERLAY_PATH = environ.get("CLRENV_OVERLAY_PATH")
+def _resolve_path(path):
+    """Resolves a user provided path. Returns None for empty string.
 
-
-def find_environment_path(name="environment.yaml"):
-    if CLRENV_PATH:
-        return CLRENV_PATH
-    path = _recursively_find_file_path(name)
+    Does not confirm the file exists.
+    """
     if not path:
-        raise Exception("%s could not be located." % name)
-    return path
+        return
+    return Path(path).expanduser().absolute()
 
 
-def find_user_environment_paths(name="environment.user.yaml"):
-    if CLRENV_OVERLAY_PATH:
-        return CLRENV_OVERLAY_PATH.split(":")
-    path = _recursively_find_file_path(name)
-    return [path] if path else []
+def _resolve_paths(paths):
+    """Resolves a user provided, colon seperated, list of paths.
+
+    Will drop values that do not exist."""
+    result = []
+    if not paths:
+        return result
+
+    for path in paths.split(":"):
+        resolved = _resolve_path(path)
+        if resolved.is_file():
+            result.append(resolved)
+        elif DEBUG_MODE:
+            logging.warning(f'Could not find "{path}" {resolved}, ignoring it.')
+    return result
 
 
-def _recursively_find_file_path(name):
-    path = "."
-    while os.path.split(os.path.abspath(path))[1]:
-        dir_path = os.path.join(path, name)
-        if os.path.exists(dir_path):
-            return os.path.abspath(dir_path)
-        path = os.path.join("..", path)
-    return None
+def _find_in_cwd_or_parents(name):
+    """Finds a file with the given name starting in the cwd and working up to root."""
+    for parent in (Path().absolute() / name).parents:
+        path = parent / name
+        if path.is_file():
+            return path
+
+
+def environment_paths():
+    """Returns a list of yaml paths that constitute the current enviroment.
+
+    Files are listed in decreasing order of precedence (overlays first). Will
+    not return an empty list. All returned path are guaranteed to exist.
+
+    Raises an exception if the base environment file can not be found.
+    """
+    result = []
+    result.extend(_resolve_paths(environ.get("CLRENV_OVERLAY_PATH")))
+    base_path = _resolve_path(environ.get("CLRENV_PATH")) or _find_in_cwd_or_parents(
+        "environment.yaml"
+    )
+    if not base_path or not base_path.is_file():
+        raise ValueError(f"Base environment file could not be located. {base_path}")
+    result.append(base_path)
+    return result

--- a/clrenv/path.py
+++ b/clrenv/path.py
@@ -22,7 +22,6 @@ DEBUG_MODE = environ.get("CLRENV_DEBUG", "").lower() in ("true", "1")
 
 def _resolve_path(path):
     """Resolves a user provided path. Returns None for empty string.
-
     Does not confirm the file exists.
     """
     if not path:
@@ -35,12 +34,9 @@ def _resolve_paths(paths):
 
     Will drop values that do not exist."""
     result = []
-    if not paths:
-        return result
-
-    for path in paths.split(":"):
+    for path in (paths or '').split(":"):
         resolved = _resolve_path(path)
-        if resolved.is_file():
+        if resolved and resolved.is_file():
             result.append(resolved)
         elif DEBUG_MODE:
             logging.warning(f'Could not find "{path}" {resolved}, ignoring it.')


### PR DESCRIPTION
Cleans up and more heavily comments environment file finding code in clrenv.

Biggest functional change is to not automatically look for overlap/user files if they are not specified explicitly by env vars. This wasn't being used (we set it explicitly in `setenv.sh`) and didn't work (we now store these under `local/` where this wasn't looking).