### PR TITLE
Keep secrets out of ClrEnv repr

### DIFF
--- a/clrenv/evaluate.py
+++ b/clrenv/evaluate.py
@@ -41,7 +41,7 @@ from typing import (
 
 from .path import environment_paths
 from .read import EnvReader
-from .types import LeafValue, NestedMapping, check_valid_leaf_value
+from .types import LeafValue, NestedMapping, Secret, check_valid_leaf_value
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +184,9 @@ class SubClrEnv(abc.MutableMapping):
         # The content of the returned mapping does not matter.
         if value is None and key in self._sub_keys:
             return {}
+
+        if isinstance(value, Secret):
+            return value.value
 
         return value
 

--- a/clrenv/read.py
+++ b/clrenv/read.py
@@ -15,14 +15,14 @@ import logging
 import os
 from collections import abc, deque
 from pathlib import Path
-from typing import Any, Deque, Iterable, Mapping, Optional, Tuple
+from typing import Any, Deque, Iterable, Mapping, Optional, Tuple, Union
 
 import boto3
 from botocore.exceptions import EndpointConnectionError  # type: ignore
 
 from .deepmerge import deepmerge
 from .path import environment_paths
-from .types import MutableNestedMapping, NestedMapping, check_valid_leaf_value
+from .types import MutableNestedMapping, NestedMapping, Secret, check_valid_leaf_value
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +108,7 @@ class EnvReader:
 
         return result
 
-    def postprocess_str(self, value: str) -> str:
+    def postprocess_str(self, value: str) -> Union[str, Secret]:
         """Post process string values."""
         # Expand environmental variables in the form of $FOO or ${FOO}.
         value = os.path.expandvars(value)
@@ -117,10 +117,10 @@ class EnvReader:
             value = os.path.expanduser(value)
         # Substitute from clrypt keyfile.
         elif value.startswith("^keyfile "):
-            value = self.evaluate_clrypt_key(value[9:])
+            value = Secret(source=value, value=self.evaluate_clrypt_key(value[9:]))
         # Substitute from aws ssm parameter store.
         elif value.startswith("^parameter "):
-            value = self.evaluate_ssm_parameter(value[11:])
+            value = Secret(source=value, value=self.evaluate_ssm_parameter(value[11:]))
 
         return value
 

--- a/clrenv/read.py
+++ b/clrenv/read.py
@@ -114,13 +114,13 @@ class EnvReader:
         value = os.path.expandvars(value)
         # If value is a path starting with ~, expand.
         if value.startswith("~"):
-            value = os.path.expanduser(value)
+            return os.path.expanduser(value)
         # Substitute from clrypt keyfile.
         elif value.startswith("^keyfile "):
-            value = Secret(source=value, value=self.evaluate_clrypt_key(value[9:]))
+            return Secret(source=value, value=self.evaluate_clrypt_key(value[9:]))
         # Substitute from aws ssm parameter store.
         elif value.startswith("^parameter "):
-            value = Secret(source=value, value=self.evaluate_ssm_parameter(value[11:]))
+            return Secret(source=value, value=self.evaluate_ssm_parameter(value[11:]))
 
         return value
 

--- a/clrenv/tests/test_read.py
+++ b/clrenv/tests/test_read.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 
 import clrenv
+from clrenv.types import Secret
 
 
 @pytest.fixture(autouse=True)
@@ -75,7 +76,8 @@ def test_clrypt(tmp_path, monkeypatch):
     env_path = tmp_path / "env"
     env_path.write_text(yaml.dump({"base": {"foo": "^keyfile aaa"}}))
     env = clrenv.read.EnvReader([env_path]).read()
-    assert env["foo"] == "bbb"
+    assert isinstance(env["foo"], Secret)
+    assert env["foo"].value == "bbb"
 
 
 def test_ssm(tmp_path, monkeypatch):
@@ -107,7 +109,8 @@ def test_ssm(tmp_path, monkeypatch):
     env_path = tmp_path / "env"
     env_path.write_text(yaml.dump({"base": {"foo": "^parameter aaa"}}))
     env = clrenv.read.EnvReader([env_path]).read()
-    assert env["foo"] == "bbb"
+    assert isinstance(env["foo"], Secret)
+    assert env["foo"].value == "bbb"
 
     env_path.write_text(yaml.dump({"base": {"foo": "^parameter endpoint_error"}}))
     with pytest.raises(botocore.exceptions.EndpointConnectionError):
@@ -124,4 +127,5 @@ def test_offline_parameter_flag(tmp_path, monkeypatch):
     env_path = tmp_path / "env"
     env_path.write_text(yaml.dump({"base": {"foo": "^parameter aaa"}}))
     env = clrenv.read.EnvReader([env_path]).read()
-    assert env["foo"] == "CLRENV_OFFLINE_PLACEHOLDER"
+    assert isinstance(env["foo"], Secret)
+    assert env["foo"].value == "CLRENV_OFFLINE_PLACEHOLDER"

--- a/clrenv/types.py
+++ b/clrenv/types.py
@@ -11,7 +11,14 @@ class Secret(NamedTuple):
     value: str
 
     def __repr__(self) -> str:
-        return self.source
+        """
+        Return a Secret's representation without exposing the secret.
+
+        In the event that a Secret's (or, more generally, a ClrEnv object's)
+        representation is logged, this will prevent us from leaking secrets into
+        plaintext.
+        """
+        return f"Secret(source='{self.source}')"
 
 
 # Type that can be read or set as values of leaf nodes.

--- a/clrenv/types.py
+++ b/clrenv/types.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Mapping, MutableMapping, Union
+from typing import Any, List, Mapping, MutableMapping, NamedTuple, Union
 
 """Defines type annotations for use in clrenv.
 
@@ -6,8 +6,16 @@ Ideally we would only allow str leaf values so that they can be migrated to an e
 var based system. For now we must supports more complex values.
 """
 
+class Secret(NamedTuple):
+    source: str
+    value: str
+
+    def __repr__(self) -> str:
+        return self.source
+
+
 # Type that can be read or set as values of leaf nodes.
-LeafValue = Union[bool, int, float, str, List[Union[bool, int, float, str]]]
+LeafValue = Union[bool, int, float, str, List[Union[bool, int, float, str]], Secret]
 # Type of a non leaf node.
 NestedMapping = Mapping[str, Union[LeafValue, Mapping[str, Any]]]
 MutableNestedMapping = MutableMapping[str, Union[LeafValue, MutableMapping[str, Any]]]


### PR DESCRIPTION
This commit updates how we handle secrets in ClrEnv objects so that logging a ClrEnv
object does not unintentionally leak secrets. This has caused at least one security
incident (see security incident 2105). By using a custom type for leaf values are
secrets, we update __repr__ to return the untransformed config value (e.g., "^keyfile
xyz"), but return the transformed value when accessed directly (e.g., env.foo).