### PR TITLE
Mark clrenv as having type hints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ setup(
     author_email="dev@getcolor.com",
     url="https://github.com/color/clrenv",
     packages=["clrenv"],
+    package_data={
+        'clrenv': ['py.typed'],
+    },
     install_requires=requirements,
     setup_requires=["pytest-runner"],
     tests_require=requirements + ["pytest", "pytest-cov"],


### PR DESCRIPTION
We are already using type hints, but without this marker file mypy won't use them when this is installed in another project.

https://peps.python.org/pep-0561/
