### PR TITLE
Fix repr of clrenv nodes to include runtime and env var overrides

### DIFF
--- a/clrenv/path.py
+++ b/clrenv/path.py
@@ -38,7 +38,9 @@ def environment_paths() -> Tuple[Path, ...]:
     if not base_path:
         base_path = _find_in_cwd_or_parents("environment.yaml")
     if not base_path or not base_path.is_file():
-        raise ValueError(f"Base environment file could not be located. {base_path}")
+        raise ValueError(
+            f"Base environment file (CLRENV_PATH) could not be located. {base_path if base_path else ''}"
+        )
     result.append(base_path)
     return tuple(result)
 

--- a/clrenv/tests/test_evaluate.py
+++ b/clrenv/tests/test_evaluate.py
@@ -205,9 +205,10 @@ def test_clrypt_secret(tmp_path, monkeypatch):
     env = clrenv.evaluate.RootClrEnv([env_path])
 
     # Check that the repr does not leak the secret, but the secret is still accessible
-    assert '^keyfile aaa' in repr(env)
-    assert 'bbb' not in repr(env)
-    assert env.foo == "bbb"    
+    assert "^keyfile aaa" in repr(env)
+    assert "bbb" not in repr(env)
+    assert env.foo == "bbb"
+
 
 def test_ssm_secret(tmp_path, monkeypatch):
     """
@@ -244,7 +245,6 @@ def test_ssm_secret(tmp_path, monkeypatch):
     env = clrenv.evaluate.RootClrEnv([env_path])
 
     # Check that the repr does not leak the secret, but the secret is still accessible
-    assert '^parameter aaa' in repr(env)
-    assert 'bbb' not in repr(env)
-    assert env.foo == "bbb"    
-
+    assert "^parameter aaa" in repr(env)
+    assert "bbb" not in repr(env)
+    assert env.foo == "bbb"

--- a/clrenv/types.py
+++ b/clrenv/types.py
@@ -6,6 +6,7 @@ Ideally we would only allow str leaf values so that they can be migrated to an e
 var based system. For now we must supports more complex values.
 """
 
+
 class Secret(NamedTuple):
     source: str
     value: str

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ requirements = ["PyYAML>=4.2", "boto3>=1.15.18"]
 
 setup(
     name="clrenv",
-    version="0.2.4",
+    version="0.2.5",
     description="A tool to give easy access to environment yaml file to python.",
     author="Color",
     author_email="dev@getcolor.com",


### PR DESCRIPTION
This caused some confusion debugging an issue. Previously it would show the value from the yaml when printing a higher level clrenv node.

```
$ CLRENV_PATH=$COLOR_ROOT/environment.yaml ENCRYPTED_DIR=$COLOR_ROOT/encrypted CLRENV__HONEYCOMB__FUNCTIONALITY_ENABLED__SERIALIZER_METHOD_FIELD=AAA python -c 'from clrenv import env; print(env.honeycomb)' 
ClrEnv[honeycomb]={'functionality_enabled': "{'serializer_method_field': 'AAA'}", 'writekey': "Secret(source='^keyfile honeycomb.writekey')"
```